### PR TITLE
Add quantity bounds test

### DIFF
--- a/src/pages/__tests__/Cart.test.tsx
+++ b/src/pages/__tests__/Cart.test.tsx
@@ -35,4 +35,30 @@ describe('updateQuantity', () => {
     fireEvent.change(input, { target: { value: '10' } });
     expect((input as HTMLInputElement).value).toBe('5');
   });
+
+  it('accepts a quantity within the available stock range', () => {
+    const cartItem = {
+      id: '1',
+      name: 'Test',
+      price: 10,
+      category: 'cat',
+      quantity: 5,
+      image: '',
+      description: '',
+      features: [],
+      weight: '1kg',
+      selectedQuantity: 2,
+    };
+    localStorage.setItem('cart', JSON.stringify([cartItem]));
+    render(
+      <MemoryRouter>
+        <Cart />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByRole('spinbutton');
+
+    fireEvent.change(input, { target: { value: '3' } });
+    expect((input as HTMLInputElement).value).toBe('3');
+  });
 });


### PR DESCRIPTION
## Summary
- add test for valid quantity range in cart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f9c172abc832a902dd0ab6dd304d5