### PR TITLE
Add admin login and signup pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import Cart from './pages/Cart';
 import Locations from './pages/Locations';
 import Contact from './pages/Contact';
 import ProductDetail from './pages/ProductDetail';
+import AdminLogin from './pages/admin/Login';
+import AdminSignup from './pages/admin/Signup';
 
 function App() {
   return (
@@ -19,6 +21,8 @@ function App() {
           <Route path="/locations" element={<Locations />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/product/:id" element={<ProductDetail />} />
+          <Route path="/admin/login" element={<AdminLogin />} />
+          <Route path="/admin/signup" element={<AdminSignup />} />
         </Routes>
       </div>
     </Router>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -22,6 +22,7 @@ export default function Navbar() {
             <Link to="/catalog" className="text-gray-600 hover:text-indigo-600">Browse Catalogs</Link>
             <Link to="/locations" className="text-gray-600 hover:text-indigo-600">Locations</Link>
             <Link to="/contact" className="text-gray-600 hover:text-indigo-600">Contact Us</Link>
+            <Link to="/admin/login" className="text-gray-600 hover:text-indigo-600">Admin</Link>
             <Link to="/cart" className="relative">
               <ShoppingCart className="h-6 w-6 text-gray-600 hover:text-indigo-600" />
             </Link>
@@ -74,6 +75,13 @@ export default function Navbar() {
               onClick={() => setIsOpen(false)}
             >
               Contact Us
+            </Link>
+            <Link
+              to="/admin/login"
+              className="block px-3 py-2 text-gray-600 hover:text-indigo-600"
+              onClick={() => setIsOpen(false)}
+            >
+              Admin
             </Link>
             <Link
               to="/cart"

--- a/src/pages/admin/Login.tsx
+++ b/src/pages/admin/Login.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+export default function AdminLogin() {
+  const [status, setStatus] = useState<'idle' | 'error'>('idle');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const email = data.get('email');
+    const password = data.get('password');
+
+    if (!email || !password) {
+      setStatus('error');
+      return;
+    }
+
+    // Placeholder login logic
+    console.log('Admin login:', email);
+  };
+
+  return (
+    <div className="pt-20 max-w-md mx-auto px-4">
+      <h1 className="text-2xl font-bold mb-6">Admin Login</h1>
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-gray-700 mb-2">Email</label>
+          <input id="email" name="email" type="email" className="w-full p-2 border rounded-md" required />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-gray-700 mb-2">Password</label>
+          <input id="password" name="password" type="password" className="w-full p-2 border rounded-md" required />
+        </div>
+        <button type="submit" className="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700">Login</button>
+        {status === 'error' && <p className="text-red-600">Please fill in all fields.</p>}
+      </form>
+    </div>
+  );
+}

--- a/src/pages/admin/Signup.tsx
+++ b/src/pages/admin/Signup.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+export default function AdminSignup() {
+  const [status, setStatus] = useState<'idle' | 'error'>('idle');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const email = data.get('email');
+    const password = data.get('password');
+    const confirm = data.get('confirm');
+
+    if (!email || !password || !confirm || password !== confirm) {
+      setStatus('error');
+      return;
+    }
+
+    // Placeholder signup logic
+    console.log('Admin signup:', email);
+  };
+
+  return (
+    <div className="pt-20 max-w-md mx-auto px-4">
+      <h1 className="text-2xl font-bold mb-6">Admin Signup</h1>
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-gray-700 mb-2">Email</label>
+          <input id="email" name="email" type="email" className="w-full p-2 border rounded-md" required />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-gray-700 mb-2">Password</label>
+          <input id="password" name="password" type="password" className="w-full p-2 border rounded-md" required />
+        </div>
+        <div>
+          <label htmlFor="confirm" className="block text-gray-700 mb-2">Confirm Password</label>
+          <input id="confirm" name="confirm" type="password" className="w-full p-2 border rounded-md" required />
+        </div>
+        <button type="submit" className="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700">Sign Up</button>
+        {status === 'error' && <p className="text-red-600">Please fill in all fields and ensure passwords match.</p>}
+      </form>
+    </div>
+  );
+}

--- a/src/pages/admin/__tests__/Admin.test.tsx
+++ b/src/pages/admin/__tests__/Admin.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AdminLogin from '../Login';
+import AdminSignup from '../Signup';
+
+describe('Admin pages', () => {
+  it('renders login page heading', () => {
+    render(
+      <MemoryRouter>
+        <AdminLogin />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Admin Login')).toBeInTheDocument();
+  });
+
+  it('renders signup page heading', () => {
+    render(
+      <MemoryRouter>
+        <AdminSignup />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Admin Signup')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create `AdminLogin` and `AdminSignup` pages
- add admin routes to the app router
- expose link to admin pages from the navbar
- test the new admin pages

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_683fdff7a6ec832a8f8011b7b6536d36